### PR TITLE
Replace balenalib base images with the official ones

### DIFF
--- a/balena.yml
+++ b/balena.yml
@@ -1,2 +1,2 @@
 type: sw.application
-version: '2.0.0'
+version: '2.2.0'

--- a/device_tags_node/Dockerfile.template
+++ b/device_tags_node/Dockerfile.template
@@ -1,8 +1,4 @@
-# base-image for node on any machine using a template variable,
-# see more about dockerfile templates here: http://docs.balena.io/deployment/docker-templates/
-# and about balena base images here: http://docs.balena.io/reference/base-images/base-images/
-# Note the node:slim image doesn't have node-gyp
-FROM balenalib/%%BALENA_ARCH%%-debian-node:18-bookworm
+FROM node:18-bookworm-slim
 
 # use apt-get if you need to install dependencies,
 # for instance if you need ALSA sound utils, just uncomment the lines below.

--- a/device_tags_node/Dockerfile.template
+++ b/device_tags_node/Dockerfile.template
@@ -1,4 +1,4 @@
-FROM node:18-bookworm-slim
+FROM node:22-bookworm-slim
 
 # use apt-get if you need to install dependencies,
 # for instance if you need ALSA sound utils, just uncomment the lines below.

--- a/device_tags_python/Dockerfile.template
+++ b/device_tags_python/Dockerfile.template
@@ -1,10 +1,10 @@
-# base-image for python on any machine using a template variable,
-# see more about dockerfile templates here: https://www.balena.io/docs/learn/develop/dockerfile/
-FROM balenalib/%%BALENA_ARCH%%-debian-python:3-bookworm
+FROM python:3-bookworm
 
-# use `install_packages` if you need to install dependencies,
-# for instance if you need git, just uncomment the line below.
-# RUN install_packages git
+# use apt-get if you need to install dependencies,
+# for instance if you need git, just uncomment the lines below.
+#RUN apt-get update && apt-get install \
+#    git && \
+#    apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Set our working directory
 WORKDIR /usr/src/app
@@ -17,9 +17,6 @@ RUN pip install -r requirements.txt
 
 # This will copy all files in our root to the working  directory in the container
 COPY . ./
-
-# Enable udevd so that plugged dynamic hardware devices show up in our container.
-# ENV UDEV=1
 
 # main.py will run when container starts up on the device
 CMD ["python","-u","src/app.py"]

--- a/repo.yml
+++ b/repo.yml
@@ -1,0 +1,1 @@
+type: generic


### PR DESCRIPTION
Change-type: minor
See: https://balena.fibery.io/Work/Project/Migrate-projects-to-Docker-official-base-images-1604